### PR TITLE
add body classes implementation

### DIFF
--- a/source/_layouts/base.liquid
+++ b/source/_layouts/base.liquid
@@ -45,7 +45,9 @@
     </script>
   </head>
 
-  <body data-layout="body">
+  {% assign classes = page.filePathStem | replace: "/", " " %}
+
+  <body data-layout="body" class="{{ classes }}">
     <!--[if lt IE 9]>
     <p class="browserupgrade">
     You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience and security.

--- a/source/_layouts/base.liquid
+++ b/source/_layouts/base.liquid
@@ -45,7 +45,7 @@
     </script>
   </head>
 
-  {% assign classes = page.filePathStem | replace: "/", " " %}
+  {%- assign classes = page.filePathStem | replace: "/", " " | strip -%}
 
   <body data-layout="body" class="{{ classes }}">
     <!--[if lt IE 9]>

--- a/source/testing/test.md
+++ b/source/testing/test.md
@@ -1,5 +1,0 @@
----
-layout: base
----
-
-testing

--- a/source/testing/test.md
+++ b/source/testing/test.md
@@ -1,0 +1,5 @@
+---
+layout: base
+---
+
+testing


### PR DESCRIPTION
Add classes to body using `page.filePathStem` and liquid `replace`. 

It adds a space before it adds the classes - e.g. `class=" community". I assume this doesn't matter but thought I'd check!