### PR TITLE
Preserve whitespace during HTML truncation (fixes code blocks).

### DIFF
--- a/source/helpers/type.ts
+++ b/source/helpers/type.ts
@@ -32,7 +32,7 @@ export const getLorem = (type: string, number = 1) => {
  * @see https://github.com/oe/truncate-html
  */
 export const truncateHTML = (html: string, words = 170) =>
-  truncate(html, words, { byWords: true });
+  truncate(html, words, { byWords: true, keepWhitespaces: true });
 
 /**
  * Renders block of Markdown into HTML.


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&522)

Compare code blocks in summary blog pages, e.g. bottom of:

- https://sass-site-oddbird.netlify.app/blog/page/4/
- https://deploy-preview-48--sass-site-oddbird.netlify.app/blog/page/4/

Before:

![Screenshot 2023-05-22 at 1 23 53 PM](https://github.com/oddbird/sass-site/assets/552316/a1753dc8-1a64-48db-a368-9441d98d0b20)

After:

![Screenshot 2023-05-22 at 1 23 58 PM](https://github.com/oddbird/sass-site/assets/552316/d3c7a225-a572-4f6c-91d9-777f383c33c6)