### PR TITLE
Use kwargs for {% compatibility %} tag.

### DIFF
--- a/source/documentation/at-rules/css.liquid
+++ b/source/documentation/at-rules/css.liquid
@@ -77,7 +77,7 @@ table_of_contents: true
     [range context]: https://www.w3.org/TR/mediaqueries-4/#mq-range-context
   {% endmarkdown %}
 
-  {% codeExample 'range-syntax', 'libsass: false' %}
+  {% codeExample 'range-syntax', false %}
     @media (width <= 700px) {
       body {
         background: green;

--- a/source/documentation/at-rules/css.liquid
+++ b/source/documentation/at-rules/css.liquid
@@ -3,8 +3,7 @@ title: CSS At-Rules
 table_of_contents: true
 ---
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility '1.15.0', false, null, false, "Name Interpolation" %}
+{% compatibility 'dart: 1.15.0', 'libsass: false', 'ruby: false', 'feature: Name Interpolation' %}
   LibSass, Ruby Sass, and older versions of Dart Sass don't support
   [interpolation][] in at-rule names. They do support interpolation in values.
 
@@ -69,8 +68,7 @@ table_of_contents: true
 
 {{ '## `@media`' | markdown }}
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, `useMarkdown` boolean, additional details within %}
-{% compatibility '1.11.0', false, null, '3.7.0', 'Range Syntax', false %}
+{% compatibility 'dart: 1.11.0', 'libsass: false', 'ruby: 3.7.0', 'feature: Range Syntax', 'useMarkdown: false' %}
   {% markdown %}
     LibSass and older versions of Dart Sass and Ruby Sass don't support media
     queries with features written in a [range context][]. They do support other
@@ -79,7 +77,7 @@ table_of_contents: true
     [range context]: https://www.w3.org/TR/mediaqueries-4/#mq-range-context
   {% endmarkdown %}
 
-  {% codeExample 'range-syntax', false %}
+  {% codeExample 'range-syntax', 'libsass: false' %}
     @media (width <= 700px) {
       body {
         background: green;

--- a/source/documentation/at-rules/css.liquid
+++ b/source/documentation/at-rules/css.liquid
@@ -3,7 +3,7 @@ title: CSS At-Rules
 table_of_contents: true
 ---
 
-{% compatibility 'dart: 1.15.0', 'libsass: false', 'ruby: false', 'feature: Name Interpolation' %}
+{% compatibility 'dart: "1.15.0"', 'libsass: false', 'ruby: false', 'feature: "Name Interpolation"' %}
   LibSass, Ruby Sass, and older versions of Dart Sass don't support
   [interpolation][] in at-rule names. They do support interpolation in values.
 
@@ -68,7 +68,7 @@ table_of_contents: true
 
 {{ '## `@media`' | markdown }}
 
-{% compatibility 'dart: 1.11.0', 'libsass: false', 'ruby: 3.7.0', 'feature: Range Syntax', 'useMarkdown: false' %}
+{% compatibility 'dart: "1.11.0"', 'libsass: false', 'ruby: "3.7.0"', 'feature: "Range Syntax"', 'useMarkdown: false' %}
   {% markdown %}
     LibSass and older versions of Dart Sass and Ruby Sass don't support media
     queries with features written in a [range context][]. They do support other

--- a/source/documentation/at-rules/extend.liquid
+++ b/source/documentation/at-rules/extend.liquid
@@ -280,7 +280,7 @@ introduction: >
 
   ### Disallowed Selectors
 
-  {% compatibility 'dart: true', 'libsass: false', 'ruby: false', 'feature: No Compound Extensions' %}
+  {% compatibility 'dart: true', 'libsass: false', 'ruby: false', 'feature: "No Compound Extensions"' %}
     LibSass and Ruby Sass currently allow compound selectors like
     `.message.info` to be extended. However, this behavior doesn't match the
     definition of `@extend`: instead of styling elements that match the

--- a/source/documentation/at-rules/extend.liquid
+++ b/source/documentation/at-rules/extend.liquid
@@ -280,8 +280,7 @@ introduction: >
 
   ### Disallowed Selectors
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility true, false, null, false, "No Compound Extensions" %}
+  {% compatibility 'dart: true', 'libsass: false', 'ruby: false', 'feature: No Compound Extensions' %}
     LibSass and Ruby Sass currently allow compound selectors like
     `.message.info` to be extended. However, this behavior doesn't match the
     definition of `@extend`: instead of styling elements that match the

--- a/source/documentation/at-rules/forward.liquid
+++ b/source/documentation/at-rules/forward.liquid
@@ -200,8 +200,7 @@ introduction: >
 {% markdown %}
   ## Configuring Modules
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.24.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.24.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   The `@forward` rule can also load a module with [configuration][]. This mostly
   works the same as it does for `@use`, with one addition: a `@forward` rule's

--- a/source/documentation/at-rules/forward.liquid
+++ b/source/documentation/at-rules/forward.liquid
@@ -200,7 +200,7 @@ introduction: >
 {% markdown %}
   ## Configuring Modules
 
-  {% compatibility 'dart: 1.24.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.24.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   The `@forward` rule can also load a module with [configuration][]. This mostly
   works the same as it does for `@use`, with one addition: a `@forward` rule's

--- a/source/documentation/at-rules/import.liquid
+++ b/source/documentation/at-rules/import.liquid
@@ -177,8 +177,7 @@ introduction: >
 
   ### Index Files
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility true, '3.6.0', null, '3.6.0' %}{% endcompatibility %}
+  {% compatibility 'dart: true', 'libsass: 3.6.0', 'ruby: 3.6.0' %}{% endcompatibility %}
 
   If you write an `_index.scss` or `_index.sass` in a folder, when the folder
   itself is imported that file will be loaded in its place.
@@ -372,8 +371,7 @@ introduction: >
 {% markdown %}
   ## Importing CSS
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.11.0', 'partial', null, false %}
+  {% compatibility 'dart: 1.11.0', 'libsass: partial', 'ruby: false' %}
     LibSass supports importing files with the extension `.css`, but contrary to
     the specification they're treated as SCSS files rather than being parsed as
     CSS. This behavior has been deprecated, and an update is in the works to
@@ -423,8 +421,7 @@ introduction: >
 
   ## Plain CSS `@import`s
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility true, 'partial', null, true %}
+  {% compatibility 'dart: true', 'libsass: partial', 'ruby: true' %}
     By default, LibSass handles plain CSS imports correctly. However, any
     [custom importers][] will incorrectly apply to plain-CSS `@import` rules,
     making it possible for those rules to load Sass files.
@@ -563,8 +560,7 @@ introduction: >
 {% markdown %}
   #### Configuring Modules Through Imports
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.24.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.24.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   You can [configure modules][] that are loaded through an `@import` by defining
   global variables prior the `@import` that first loads that module.

--- a/source/documentation/at-rules/import.liquid
+++ b/source/documentation/at-rules/import.liquid
@@ -177,7 +177,7 @@ introduction: >
 
   ### Index Files
 
-  {% compatibility 'dart: true', 'libsass: 3.6.0', 'ruby: 3.6.0' %}{% endcompatibility %}
+  {% compatibility 'dart: true', 'libsass: "3.6.0"', 'ruby: "3.6.0"' %}{% endcompatibility %}
 
   If you write an `_index.scss` or `_index.sass` in a folder, when the folder
   itself is imported that file will be loaded in its place.
@@ -371,7 +371,7 @@ introduction: >
 {% markdown %}
   ## Importing CSS
 
-  {% compatibility 'dart: 1.11.0', 'libsass: partial', 'ruby: false' %}
+  {% compatibility 'dart: "1.11.0"', 'libsass: "partial"', 'ruby: false' %}
     LibSass supports importing files with the extension `.css`, but contrary to
     the specification they're treated as SCSS files rather than being parsed as
     CSS. This behavior has been deprecated, and an update is in the works to
@@ -421,7 +421,7 @@ introduction: >
 
   ## Plain CSS `@import`s
 
-  {% compatibility 'dart: true', 'libsass: partial', 'ruby: true' %}
+  {% compatibility 'dart: true', 'libsass: "partial"', 'ruby: true' %}
     By default, LibSass handles plain CSS imports correctly. However, any
     [custom importers][] will incorrectly apply to plain-CSS `@import` rules,
     making it possible for those rules to load Sass files.
@@ -560,7 +560,7 @@ introduction: >
 {% markdown %}
   #### Configuring Modules Through Imports
 
-  {% compatibility 'dart: 1.24.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.24.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   You can [configure modules][] that are loaded through an `@import` by defining
   global variables prior the `@import` that first loads that module.

--- a/source/documentation/at-rules/mixin.liquid
+++ b/source/documentation/at-rules/mixin.liquid
@@ -386,7 +386,7 @@ introduction: >
 {% markdown %}
   ### Passing Arguments to Content Blocks
 
-  {% compatibility 'dart: 1.15.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.15.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   A mixin can pass arguments to its content block the same way it would pass
   arguments to another mixin by writing `@content(<arguments...>)`. The user

--- a/source/documentation/at-rules/mixin.liquid
+++ b/source/documentation/at-rules/mixin.liquid
@@ -386,8 +386,7 @@ introduction: >
 {% markdown %}
   ### Passing Arguments to Content Blocks
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.15.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.15.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   A mixin can pass arguments to its content block the same way it would pass
   arguments to another mixin by writing `@content(<arguments...>)`. The user

--- a/source/documentation/breaking-changes/bogus-combinators.liquid
+++ b/source/documentation/breaking-changes/bogus-combinators.liquid
@@ -51,7 +51,7 @@ introduction: >
 
   ## Transition Period
 
-  {% compatibility 'dart: 1.54.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.54.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   First, we'll emit deprecation warnings for all double combinators, as well as
   leading or trailing combinators that end up in selectors after nesting is

--- a/source/documentation/breaking-changes/bogus-combinators.liquid
+++ b/source/documentation/breaking-changes/bogus-combinators.liquid
@@ -51,8 +51,7 @@ introduction: >
 
   ## Transition Period
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.54.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.54.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   First, we'll emit deprecation warnings for all double combinators, as well as
   leading or trailing combinators that end up in selectors after nesting is

--- a/source/documentation/breaking-changes/css-vars.liquid
+++ b/source/documentation/breaking-changes/css-vars.liquid
@@ -7,8 +7,7 @@ introduction: >
   values. But this wasn't compatible with CSS.
 ---
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility true, '3.5.0', null, '3.5.0' %}{% endcompatibility %}
+{% compatibility 'dart: true', 'libsass: 3.5.0', 'ruby: 3.5.0' %}{% endcompatibility %}
 
 {% markdown %}
   The CSS spec allows almost any string of characters to be used in a custom

--- a/source/documentation/breaking-changes/css-vars.liquid
+++ b/source/documentation/breaking-changes/css-vars.liquid
@@ -7,7 +7,7 @@ introduction: >
   values. But this wasn't compatible with CSS.
 ---
 
-{% compatibility 'dart: true', 'libsass: 3.5.0', 'ruby: 3.5.0' %}{% endcompatibility %}
+{% compatibility 'dart: true', 'libsass: "3.5.0"', 'ruby: "3.5.0"' %}{% endcompatibility %}
 
 {% markdown %}
   The CSS spec allows almost any string of characters to be used in a custom

--- a/source/documentation/breaking-changes/duplicate-var-flags.md
+++ b/source/documentation/breaking-changes/duplicate-var-flags.md
@@ -8,7 +8,7 @@ introduction: >
 
 ## Phase 1
 
-{% compatibility 'dart: 2.0.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+{% compatibility 'dart: "2.0.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 Starting in Dart Sass 2.0.0, if a single variable declaration has more than one
 each `!global` or `!default` flag, this will be a syntax error. This means that
@@ -17,7 +17,7 @@ each `!global` or `!default` flag, this will be a syntax error. This means that
 
 ## Transition Period
 
-{% compatibility 'dart: 1.62.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+{% compatibility 'dart: "1.62.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 Until Dart Sass 2.0.0 is released, multiple copies of a flag just produce
 deprecation warnings.

--- a/source/documentation/breaking-changes/duplicate-var-flags.md
+++ b/source/documentation/breaking-changes/duplicate-var-flags.md
@@ -8,8 +8,7 @@ introduction: >
 
 ## Phase 1
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility '2.0.0', false, null, false %}{% endcompatibility %}
+{% compatibility 'dart: 2.0.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 Starting in Dart Sass 2.0.0, if a single variable declaration has more than one
 each `!global` or `!default` flag, this will be a syntax error. This means that
@@ -18,8 +17,7 @@ each `!global` or `!default` flag, this will be a syntax error. This means that
 
 ## Transition Period
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility '1.62.0', false, null, false %}{% endcompatibility %}
+{% compatibility 'dart: 1.62.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 Until Dart Sass 2.0.0 is released, multiple copies of a flag just produce
 deprecation warnings.

--- a/source/documentation/breaking-changes/extend-compound.liquid
+++ b/source/documentation/breaking-changes/extend-compound.liquid
@@ -6,8 +6,7 @@ introduction: >
   doesn't match the way `@extend` is meant to work.
 ---
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility true, false, null, false %}{% endcompatibility %}
+{% compatibility 'dart: true', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 {% markdown %}
   When one selector extends another, Sass styles all elements that match the

--- a/source/documentation/breaking-changes/function-units.liquid
+++ b/source/documentation/breaking-changes/function-units.liquid
@@ -9,7 +9,7 @@ introduction: >
 {% markdown %}
   ## Hue
 
-  {% compatibility 'dart: 1.32.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.32.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   When specifying a color's hue, CSS allows any [angle unit][] (`deg`, `grad`,
   `rad`, or `turn`). It also allows a unitless number, which is interpreted as
@@ -25,7 +25,7 @@ introduction: >
 
   ### Phase 1{#hue-phase-1}
 
-  {% compatibility 'dart: 1.32.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.32.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   At first, Sass just emitted a deprecation warning if you passed a number with
   a unit other than `deg` as a hue to any function. Passing a unitless number is
@@ -33,7 +33,7 @@ introduction: >
 
   ### Phase 2{#hue-phase-2}
 
-  {% compatibility 'dart: 1.52.1', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.52.1"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Next, we changed the way angle units are handled for hue parameters to match
   the CSS spec. This means that numbers with `grad`, `rad`, or `turn` units will
@@ -67,7 +67,7 @@ introduction: >
 
   ### Phase 1{#saturation-lightness-phase-1}
 
-  {% compatibility 'dart: 1.32.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.32.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass just emits a deprecation warning if you pass a number with no
   unit or a unit other than `%` as a lightness or saturation to any function.
@@ -95,7 +95,7 @@ introduction: >
 
   ### Phase 1{#alpha-phase-1}
 
-  {% compatibility 'dart: 1.56.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.56.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass just emits a deprecation warning if you pass a number with any
   unit, including `%`, as an alpha value to `color.change()` or
@@ -147,7 +147,7 @@ introduction: >
 {% markdown %}
   ### Phase 1{#math-random-phase-1}
 
-  {% compatibility 'dart: 1.54.5', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.54.5"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass emits a deprecation warning if you pass a `$limit` with units
   to `math.random()`.
@@ -178,7 +178,7 @@ introduction: >
 
   ### Phase 1{#weight-phase-1}
 
-  {% compatibility 'dart: 1.56.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.56.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass emits a deprecation warning if you pass a `$weight` with no
   units or with units other than `%` to `color.mix()` or `color.invert()`.
@@ -201,7 +201,7 @@ introduction: >
 
   ### Phase 1{#index-phase-1}
 
-  {% compatibility 'dart: 1.56.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.56.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass emits a deprecation warning if you pass a `$weight` with no
   units or with units other than `%` to `color.mix()` or `color.invert()`.

--- a/source/documentation/breaking-changes/function-units.liquid
+++ b/source/documentation/breaking-changes/function-units.liquid
@@ -9,8 +9,7 @@ introduction: >
 {% markdown %}
   ## Hue
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.32.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.32.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   When specifying a color's hue, CSS allows any [angle unit][] (`deg`, `grad`,
   `rad`, or `turn`). It also allows a unitless number, which is interpreted as
@@ -26,8 +25,7 @@ introduction: >
 
   ### Phase 1{#hue-phase-1}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.32.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.32.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   At first, Sass just emitted a deprecation warning if you passed a number with
   a unit other than `deg` as a hue to any function. Passing a unitless number is
@@ -35,8 +33,7 @@ introduction: >
 
   ### Phase 2{#hue-phase-2}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.52.1', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.52.1', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Next, we changed the way angle units are handled for hue parameters to match
   the CSS spec. This means that numbers with `grad`, `rad`, or `turn` units will
@@ -52,8 +49,7 @@ introduction: >
 
   ### Phase 3{#hue-phase-3}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility false, false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: false', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Finally, in Dart Sass 2.0.0 color functions will throw errors if they're
   passed a hue parameter with a non-angle unit. Unitless hues will still be
@@ -71,16 +67,14 @@ introduction: >
 
   ### Phase 1{#saturation-lightness-phase-1}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.32.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.32.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass just emits a deprecation warning if you pass a number with no
   unit or a unit other than `%` as a lightness or saturation to any function.
 
   ### Phase 2{#saturation-lightness-phase-2}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility false, false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: false', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   In Dart Sass 2.0.0 color functions will throw errors if they're passed a
   saturation or lightness parameter with no unit or a non-`%` unit.
@@ -101,8 +95,7 @@ introduction: >
 
   ### Phase 1{#alpha-phase-1}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.56.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.56.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass just emits a deprecation warning if you pass a number with any
   unit, including `%`, as an alpha value to `color.change()` or
@@ -110,8 +103,7 @@ introduction: >
 
   ### Phase 2{#alpha-phase-2}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility false, false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: false', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Next, we'll change the way `%` units are handled for the alpha argument to
   `color.change()` and `color.adjust()`. Alphas with unit `%` will be divided by
@@ -126,8 +118,7 @@ introduction: >
 
   ### Phase 3{#alpha-phase-3}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility false, false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: false', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Finally, in Dart Sass 2.0.0 `color.change()` and `color.adjust()` will throw
   errors if they're passed an alpha parameter with a non-`%` unit. Unitless
@@ -156,23 +147,20 @@ introduction: >
 {% markdown %}
   ### Phase 1{#math-random-phase-1}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.54.5', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.54.5', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass emits a deprecation warning if you pass a `$limit` with units
   to `math.random()`.
 
   ### Phase 2{#math-random-phase-2}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility false, false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: false', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   In Dart Sass 2.0.0, passing a `$limit` number with units will be an error.
 
   ### Phase 3{#math-random-phase-3}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility false, false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: false', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   In a minor release after Dart Sass 2.0.0, passing a `$limit` number with units
   to the `math.random()` function will be allowed again. It will return a random
@@ -190,16 +178,14 @@ introduction: >
 
   ### Phase 1{#weight-phase-1}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.56.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.56.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass emits a deprecation warning if you pass a `$weight` with no
   units or with units other than `%` to `color.mix()` or `color.invert()`.
 
   ### Phase 2{#weight-phase-2}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility false, false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: false', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   In Dart Sass 2.0.0, `color.mix()` and `color.invert()` will throw errors if
   they're passed a `$weight` with no unit or a non-`%` unit.
@@ -215,16 +201,14 @@ introduction: >
 
   ### Phase 1{#index-phase-1}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.56.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.56.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   Currently, Sass emits a deprecation warning if you pass a `$weight` with no
   units or with units other than `%` to `color.mix()` or `color.invert()`.
 
   ### Phase 2{#index-phase-2}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility false, false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: false', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   In Dart Sass 2.0.0, `list.nth()` and `list.set-nth()` will throw errors if
   they're passed an index `$n` with a unit.

--- a/source/documentation/breaking-changes/media-logic.md
+++ b/source/documentation/breaking-changes/media-logic.md
@@ -6,7 +6,7 @@ introduction: >
   deprecated and is now interpreted according to the CSS standard.
 ---
 
-{% compatibility 'dart: 1.56.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+{% compatibility 'dart: "1.56.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 Because Sass supports almost any Sass expression in parenthesized media
 conditions, there were a few constructs whose meaning was changed by adding full
@@ -23,7 +23,7 @@ Fortunately, these came up very infrequently in practice.
 
 ## Transition Period
 
-{% compatibility 'dart: 1.54.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+{% compatibility 'dart: "1.54.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 First, we emitted deprecation warnings for the previous ambiguous cases. These
 will have suggestions for how to preserve the existing behavior or how to use

--- a/source/documentation/breaking-changes/media-logic.md
+++ b/source/documentation/breaking-changes/media-logic.md
@@ -6,8 +6,7 @@ introduction: >
   deprecated and is now interpreted according to the CSS standard.
 ---
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility '1.56.0', false, null, false %}{% endcompatibility %}
+{% compatibility 'dart: 1.56.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 Because Sass supports almost any Sass expression in parenthesized media
 conditions, there were a few constructs whose meaning was changed by adding full
@@ -24,8 +23,7 @@ Fortunately, these came up very infrequently in practice.
 
 ## Transition Period
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility '1.54.0', false, null, false %}{% endcompatibility %}
+{% compatibility 'dart: 1.54.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 First, we emitted deprecation warnings for the previous ambiguous cases. These
 will have suggestions for how to preserve the existing behavior or how to use

--- a/source/documentation/breaking-changes/moz-document.liquid
+++ b/source/documentation/breaking-changes/moz-document.liquid
@@ -32,8 +32,7 @@ introduction: >
 {% markdown %}
   ## Transition Period
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.7.2', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.7.2', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   First, we'll emit deprecation warnings for all usages of `@-moz-document`
   except for the empty url-prefix hack.

--- a/source/documentation/breaking-changes/moz-document.liquid
+++ b/source/documentation/breaking-changes/moz-document.liquid
@@ -32,7 +32,7 @@ introduction: >
 {% markdown %}
   ## Transition Period
 
-  {% compatibility 'dart: 1.7.2', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.7.2"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   First, we'll emit deprecation warnings for all usages of `@-moz-document`
   except for the empty url-prefix hack.

--- a/source/documentation/breaking-changes/slash-div.liquid
+++ b/source/documentation/breaking-changes/slash-div.liquid
@@ -7,7 +7,7 @@ introduction: >
   `/` as a separator.
 ---
 
-{% compatibility 'dart: partial', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+{% compatibility 'dart: "partial"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 {% markdown %}
   Today, Sass uses [complex heuristics][] to figure out whether a `/` should be
@@ -53,7 +53,7 @@ introduction: >
 {% markdown %}
   ## Transition Period
 
-  {% compatibility 'dart: 1.33.0', 'libsass: false', 'ruby: false', 'feature: math.div() and list.slash()' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.33.0"', 'libsass: false', 'ruby: false', 'feature: "math.div() and list.slash()"' %}{% endcompatibility %}
 
   To ease the transition, we've begun by adding the `math.div()` function. The
   `/` operator still does division for now, but it also prints a deprecation
@@ -112,7 +112,7 @@ introduction: >
   }
 {% endcodeExample %}
 
-{% compatibility 'dart: 1.40.0', 'libsass: false', 'ruby: false', 'feature: First-class calc' %}{% endcompatibility %}
+{% compatibility 'dart: "1.40.0"', 'libsass: false', 'ruby: false', 'feature: "First-class calc"' %}{% endcompatibility %}
 
 {% markdown %}
   Alternatively, users can wrap division operations inside a `calc()`

--- a/source/documentation/breaking-changes/slash-div.liquid
+++ b/source/documentation/breaking-changes/slash-div.liquid
@@ -7,8 +7,7 @@ introduction: >
   `/` as a separator.
 ---
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility 'partial', false, null, false %}{% endcompatibility %}
+{% compatibility 'dart: partial', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
 {% markdown %}
   Today, Sass uses [complex heuristics][] to figure out whether a `/` should be
@@ -54,8 +53,7 @@ introduction: >
 {% markdown %}
   ## Transition Period
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.33.0', false, null, false, 'math.div() and list.slash()' %}{% endcompatibility %}
+  {% compatibility 'dart: 1.33.0', 'libsass: false', 'ruby: false', 'feature: math.div() and list.slash()' %}{% endcompatibility %}
 
   To ease the transition, we've begun by adding the `math.div()` function. The
   `/` operator still does division for now, but it also prints a deprecation
@@ -114,8 +112,7 @@ introduction: >
   }
 {% endcodeExample %}
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility '1.40.0', false, null, false, 'First-class calc' %}{% endcompatibility %}
+{% compatibility 'dart: 1.40.0', 'libsass: false', 'ruby: false', 'feature: First-class calc' %}{% endcompatibility %}
 
 {% markdown %}
   Alternatively, users can wrap division operations inside a `calc()`

--- a/source/documentation/breaking-changes/strict-unary.liquid
+++ b/source/documentation/breaking-changes/strict-unary.liquid
@@ -46,8 +46,7 @@ introduction: >
 
   ## Transition Period
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility '1.55.0', false, null, false %}{% endcompatibility %}
+  {% compatibility 'dart: 1.55.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   We'll make this an error in Dart Sass 2.0.0, but until then it'll just emit a
   deprecation warning.

--- a/source/documentation/breaking-changes/strict-unary.liquid
+++ b/source/documentation/breaking-changes/strict-unary.liquid
@@ -46,7 +46,7 @@ introduction: >
 
   ## Transition Period
 
-  {% compatibility 'dart: 1.55.0', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
+  {% compatibility 'dart: "1.55.0"', 'libsass: false', 'ruby: false' %}{% endcompatibility %}
 
   We'll make this an error in Dart Sass 2.0.0, but until then it'll just emit a
   deprecation warning.

--- a/source/documentation/cli/dart-sass.md
+++ b/source/documentation/cli/dart-sass.md
@@ -36,7 +36,7 @@ SCSS unless the [`--indented` flag][] is passed.
 
 ### Many-to-Many Mode
 
-{% compatibility '1.4.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.4.0' %}{% endcompatibility %}
 
 ```shellsession
 sass [<input.scss>:<output.css>] [<input/>:<output/>]...
@@ -140,7 +140,7 @@ h1{font-size:40px}
 
 #### `--no-charset`
 
-{% compatibility '1.19.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.19.0' %}{% endcompatibility %}
 
 This flag tells Sass never to emit a `@charset` declaration or a UTF-8
 [byte-order mark][]. By default, or if `--charset` is passed, Sass will insert
@@ -164,7 +164,7 @@ h1::before {
 
 #### `--error-css`
 
-{% compatibility '1.20.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.20.0' %}{% endcompatibility %}
 
 This flag tells Sass whether to emit a CSS file when an error occurs during
 compilation. This CSS file describes the error in a comment _and_ in the
@@ -208,7 +208,7 @@ Error: Incompatible units em and px.
 
 #### `--update`
 
-{% compatibility '1.4.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.4.0' %}{% endcompatibility %}
 
 If the `--update` flag is passed, Sass will only compile stylesheets whose
 dependencies have been modified more recently than the corresponding CSS file
@@ -221,7 +221,7 @@ Compiled themes/light.scss to public/css/light.css.
 
 ### Source Maps
 
-{% compatibility '1.3.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.3.0' %}{% endcompatibility %}
 
 {% render 'documentation/snippets/source-maps' %}
 
@@ -283,7 +283,7 @@ $ sass --embed-source-map sass/style.scss css.style.css
 
 #### `--watch`
 
-{% compatibility '1.6.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.6.0' %}{% endcompatibility %}
 
 This flag (abbreviated `-w`) acts like the [`--update` flag][], but after the
 first round compilation is done Sass stays open and continues compiling
@@ -306,7 +306,7 @@ Compiled themes/dark.scss to public/css/dark.css.
 
 #### `--poll`
 
-{% compatibility '1.8.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.8.0' %}{% endcompatibility %}
 
 This flag, which may only be passed along with `--watch`, tells Sass to manually
 check for changes to the source files every so often instead of relying on the
@@ -324,7 +324,7 @@ Compiled themes/dark.scss to public/css/dark.css.
 
 #### `--stop-on-error`
 
-{% compatibility '1.8.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.8.0' %}{% endcompatibility %}
 
 This flag tells Sass to stop compiling immediately when an error is detected,
 rather than trying to compile other Sass files that may not contain errors. It's
@@ -342,7 +342,7 @@ Error: Expected expression.
 
 #### `--interactive`
 
-{% compatibility '1.5.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.5.0' %}{% endcompatibility %}
 
 This flag (abbreviated `-i`) tells Sass to run in interactive mode, where you
 can write [SassScript expressions][] and see their results. Interactive mode
@@ -389,7 +389,7 @@ Error: Incompatible units em and px.
 
 #### `--no-unicode`
 
-{% compatibility '1.17.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.17.0' %}{% endcompatibility %}
 
 This flag tells Sass only to emit ASCII characters to the terminal as part of
 error messages. By default, or if `--unicode` is passed, Sass will emit non-ASCII
@@ -439,7 +439,7 @@ $ sass --load-path=node_modules --quiet-deps style.scss style.css
 
 #### `--fatal-deprecation`
 
-{% compatibility '1.59.0' %}{% endcompatibility %}
+{% compatibility 'dart: 1.59.0' %}{% endcompatibility %}
 
 This option tells Sass to treat a particular type of deprecation warning as
 an error. For example, this command tells Sass to treat deprecation

--- a/source/documentation/cli/dart-sass.md
+++ b/source/documentation/cli/dart-sass.md
@@ -36,7 +36,7 @@ SCSS unless the [`--indented` flag][] is passed.
 
 ### Many-to-Many Mode
 
-{% compatibility 'dart: 1.4.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.4.0"' %}{% endcompatibility %}
 
 ```shellsession
 sass [<input.scss>:<output.css>] [<input/>:<output/>]...
@@ -140,7 +140,7 @@ h1{font-size:40px}
 
 #### `--no-charset`
 
-{% compatibility 'dart: 1.19.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.19.0"' %}{% endcompatibility %}
 
 This flag tells Sass never to emit a `@charset` declaration or a UTF-8
 [byte-order mark][]. By default, or if `--charset` is passed, Sass will insert
@@ -164,7 +164,7 @@ h1::before {
 
 #### `--error-css`
 
-{% compatibility 'dart: 1.20.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.20.0"' %}{% endcompatibility %}
 
 This flag tells Sass whether to emit a CSS file when an error occurs during
 compilation. This CSS file describes the error in a comment _and_ in the
@@ -208,7 +208,7 @@ Error: Incompatible units em and px.
 
 #### `--update`
 
-{% compatibility 'dart: 1.4.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.4.0"' %}{% endcompatibility %}
 
 If the `--update` flag is passed, Sass will only compile stylesheets whose
 dependencies have been modified more recently than the corresponding CSS file
@@ -221,7 +221,7 @@ Compiled themes/light.scss to public/css/light.css.
 
 ### Source Maps
 
-{% compatibility 'dart: 1.3.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.3.0"' %}{% endcompatibility %}
 
 {% render 'documentation/snippets/source-maps' %}
 
@@ -283,7 +283,7 @@ $ sass --embed-source-map sass/style.scss css.style.css
 
 #### `--watch`
 
-{% compatibility 'dart: 1.6.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.6.0"' %}{% endcompatibility %}
 
 This flag (abbreviated `-w`) acts like the [`--update` flag][], but after the
 first round compilation is done Sass stays open and continues compiling
@@ -306,7 +306,7 @@ Compiled themes/dark.scss to public/css/dark.css.
 
 #### `--poll`
 
-{% compatibility 'dart: 1.8.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.8.0"' %}{% endcompatibility %}
 
 This flag, which may only be passed along with `--watch`, tells Sass to manually
 check for changes to the source files every so often instead of relying on the
@@ -324,7 +324,7 @@ Compiled themes/dark.scss to public/css/dark.css.
 
 #### `--stop-on-error`
 
-{% compatibility 'dart: 1.8.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.8.0"' %}{% endcompatibility %}
 
 This flag tells Sass to stop compiling immediately when an error is detected,
 rather than trying to compile other Sass files that may not contain errors. It's
@@ -342,7 +342,7 @@ Error: Expected expression.
 
 #### `--interactive`
 
-{% compatibility 'dart: 1.5.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.5.0"' %}{% endcompatibility %}
 
 This flag (abbreviated `-i`) tells Sass to run in interactive mode, where you
 can write [SassScript expressions][] and see their results. Interactive mode
@@ -389,7 +389,7 @@ Error: Incompatible units em and px.
 
 #### `--no-unicode`
 
-{% compatibility 'dart: 1.17.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.17.0"' %}{% endcompatibility %}
 
 This flag tells Sass only to emit ASCII characters to the terminal as part of
 error messages. By default, or if `--unicode` is passed, Sass will emit non-ASCII
@@ -439,7 +439,7 @@ $ sass --load-path=node_modules --quiet-deps style.scss style.css
 
 #### `--fatal-deprecation`
 
-{% compatibility 'dart: 1.59.0' %}{% endcompatibility %}
+{% compatibility 'dart: "1.59.0"' %}{% endcompatibility %}
 
 This option tells Sass to treat a particular type of deprecation warning as
 an error. For example, this command tells Sass to treat deprecation

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -41,16 +41,14 @@ there may be some behavioral differences.
 Anywhere behavior differs between versions or implementations, the documentation
 includes a compatibility indicator like this:
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility true, '3.6.0', null, false, 'Feature Name' %}{% endcompatibility %}
+{% compatibility 'dart: true', 'libsass: 3.6.0', 'ruby: false', 'feature: Feature Name' %}{% endcompatibility %}
 
 Implementations with a "✓" fully support the feature in question, and
 implementations with a "✗" don't support it all. Implementations with a version
 number started supporting the feature in question at that version.
 Implementations can also be marked as "partial":
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility true, 'partial', null, false %}
+{% compatibility 'dart: true', 'libsass: partial', 'ruby: false' %}
   Additional details go here.
 {% endcompatibility %}
 

--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -41,14 +41,14 @@ there may be some behavioral differences.
 Anywhere behavior differs between versions or implementations, the documentation
 includes a compatibility indicator like this:
 
-{% compatibility 'dart: true', 'libsass: 3.6.0', 'ruby: false', 'feature: Feature Name' %}{% endcompatibility %}
+{% compatibility 'dart: true', 'libsass: "3.6.0"', 'ruby: false', 'feature: "Feature Name"' %}{% endcompatibility %}
 
 Implementations with a "✓" fully support the feature in question, and
 implementations with a "✗" don't support it all. Implementations with a version
 number started supporting the feature in question at that version.
 Implementations can also be marked as "partial":
 
-{% compatibility 'dart: true', 'libsass: partial', 'ruby: false' %}
+{% compatibility 'dart: true', 'libsass: "partial"', 'ruby: false' %}
   Additional details go here.
 {% endcompatibility %}
 

--- a/source/documentation/interpolation.liquid
+++ b/source/documentation/interpolation.liquid
@@ -48,8 +48,7 @@ introduction: >
 {% markdown %}
   ## In SassScript
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility true, false, null, '4.0.0 (unreleased)', 'Modern Syntax' %}
+  {% compatibility 'dart: true', 'libsass: false', 'ruby: 4.0.0 (unreleased)', 'feature: Modern Syntax' %}
     LibSass and Ruby Sass currently use an older syntax for parsing
     interpolation in SassScript. For most practical purposes it works the same,
     but it can behave strangely around [operators][]. See [this document][] for

--- a/source/documentation/interpolation.liquid
+++ b/source/documentation/interpolation.liquid
@@ -48,7 +48,7 @@ introduction: >
 {% markdown %}
   ## In SassScript
 
-  {% compatibility 'dart: true', 'libsass: false', 'ruby: 4.0.0 (unreleased)', 'feature: Modern Syntax' %}
+  {% compatibility 'dart: true', 'libsass: false', 'ruby: "4.0.0 (unreleased)"', 'feature: "Modern Syntax"' %}
     LibSass and Ruby Sass currently use an older syntax for parsing
     interpolation in SassScript. For most practical purposes it works the same,
     but it can behave strangely around [operators][]. See [this document][] for

--- a/source/documentation/snippets/module-system-status.liquid
+++ b/source/documentation/snippets/module-system-status.liquid
@@ -1,5 +1,4 @@
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility '1.23.0', false, null, false %}
+{% compatibility 'dart: 1.23.0', 'libsass: false', 'ruby: false' %}
   Only Dart Sass currently supports `@use`. Users of other implementations must
   use the [`@import` rule][] instead.
 

--- a/source/documentation/snippets/module-system-status.liquid
+++ b/source/documentation/snippets/module-system-status.liquid
@@ -1,4 +1,4 @@
-{% compatibility 'dart: 1.23.0', 'libsass: false', 'ruby: false' %}
+{% compatibility 'dart: "1.23.0"', 'libsass: false', 'ruby: false' %}
   Only Dart Sass currently supports `@use`. Users of other implementations must
   use the [`@import` rule][] instead.
 

--- a/source/documentation/style-rules/declarations.liquid
+++ b/source/documentation/style-rules/declarations.liquid
@@ -139,8 +139,7 @@ introduction: >
 {% markdown %}
   ## Custom Properties
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility true, '3.5.0', null, '3.5.0', 'SassScript Syntax' %}
+  {% compatibility 'dart: true', 'libsass: 3.5.0', 'ruby: 3.5.0', 'feature: SassScript Syntax' %}
     Older versions of LibSass and Ruby Sass parsed custom property declarations
     just like any other property declaration, allowing the full range of
     SassScript expressions as values. Even when using these versions, it's

--- a/source/documentation/style-rules/declarations.liquid
+++ b/source/documentation/style-rules/declarations.liquid
@@ -139,7 +139,7 @@ introduction: >
 {% markdown %}
   ## Custom Properties
 
-  {% compatibility 'dart: true', 'libsass: 3.5.0', 'ruby: 3.5.0', 'feature: SassScript Syntax' %}
+  {% compatibility 'dart: true', 'libsass: "3.5.0"', 'ruby: "3.5.0"', 'feature: "SassScript Syntax"' %}
     Older versions of LibSass and Ruby Sass parsed custom property declarations
     just like any other property declaration, allowing the full range of
     SassScript expressions as values. Even when using these versions, it's

--- a/source/documentation/syntax/parsing.md
+++ b/source/documentation/syntax/parsing.md
@@ -7,8 +7,7 @@ introduction: >
 
 ## Input Encoding
 
-{% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-{% compatibility false, true, null, true %}
+{% compatibility 'dart: false', 'libsass: true', 'ruby: true' %}
   Dart Sass currently *only* supports the UTF-8 encoding. As such, it's safest
   to encode all Sass stylesheets as UTF-8.
 {% endcompatibility %}

--- a/source/documentation/syntax/special-functions.liquid
+++ b/source/documentation/syntax/special-functions.liquid
@@ -90,8 +90,7 @@ introduction: >
 {% markdown %}
   ## `element()`, `progid:...()`, and `expression()`
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility "<1.40.0", false, null, false, "calc()" %}
+  {% compatibility 'dart: <1.40.0', 'libsass: false', 'ruby: false', 'feature: calc()' %}
     LibSass, Ruby Sass, and versions of Dart Sass prior to 1.40.0 parse `calc()`
     as special syntactic function like `element()`.
 
@@ -100,8 +99,7 @@ introduction: >
     [calculation]: /documentation/values/calculations
   {% endcompatibility %}
 
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility ">=1.31.0 <1.40.0", false, null, false, "clamp()" %}
+  {% compatibility 'dart: >=1.31.0 <1.40.0', 'libsass: false', 'ruby: false', 'feature: clamp()' %}
     LibSass, Ruby Sass, and versions of Dart Sass prior to 1.31.0 parse
     `clamp()` as a [plain CSS function] rather than supporting special syntax
     within it.

--- a/source/documentation/syntax/special-functions.liquid
+++ b/source/documentation/syntax/special-functions.liquid
@@ -90,7 +90,7 @@ introduction: >
 {% markdown %}
   ## `element()`, `progid:...()`, and `expression()`
 
-  {% compatibility 'dart: <1.40.0', 'libsass: false', 'ruby: false', 'feature: calc()' %}
+  {% compatibility 'dart: "<1.40.0"', 'libsass: false', 'ruby: false', 'feature: "calc()"' %}
     LibSass, Ruby Sass, and versions of Dart Sass prior to 1.40.0 parse `calc()`
     as special syntactic function like `element()`.
 
@@ -99,7 +99,7 @@ introduction: >
     [calculation]: /documentation/values/calculations
   {% endcompatibility %}
 
-  {% compatibility 'dart: >=1.31.0 <1.40.0', 'libsass: false', 'ruby: false', 'feature: clamp()' %}
+  {% compatibility 'dart: ">=1.31.0 <1.40.0"', 'libsass: false', 'ruby: false', 'feature: "clamp()"' %}
     LibSass, Ruby Sass, and versions of Dart Sass prior to 1.31.0 parse
     `clamp()` as a [plain CSS function] rather than supporting special syntax
     within it.

--- a/source/documentation/variables.liquid
+++ b/source/documentation/variables.liquid
@@ -239,7 +239,7 @@ introduction: >
 {% endcodeExample %}
 
 {% headsUp %}
-  {% compatibility 'dart: 2.0.0', 'libsass: false', 'ruby: false' %}
+  {% compatibility 'dart: "2.0.0"', 'libsass: false', 'ruby: false' %}
     Older Sass versions allowed `!global` to be used for a variable that doesn't
     exist yet. This behavior was deprecated to make sure each stylesheet
     declares the same variables no matter how it's executed.

--- a/source/documentation/variables.liquid
+++ b/source/documentation/variables.liquid
@@ -239,8 +239,7 @@ introduction: >
 {% endcodeExample %}
 
 {% headsUp %}
-  {% # Arguments are (in order): `dart`, `libsass`, `node`, `ruby`, optional feature name, additional details within %}
-  {% compatibility "2.0.0", false, null, false %}
+  {% compatibility 'dart: 2.0.0', 'libsass: false', 'ruby: false' %}
     Older Sass versions allowed `!global` to be used for a variable that doesn't
     exist yet. This behavior was deprecated to make sure each stylesheet
     declares the same variables no matter how it's executed.

--- a/source/helpers/components/compatibility.ts
+++ b/source/helpers/components/compatibility.ts
@@ -9,7 +9,7 @@ import { liquidEngine } from '../engines';
  *
  * - `true`, indicating that that implementation fully supports the feature;
  * - `false`, indicating that it does not yet support the feature at all;
- * - `'partial'`, indicating that it has limited or incorrect support for the
+ * - `"partial"`, indicating that it has limited or incorrect support for the
  *   feature;
  * - or a string, indicating the version it started supporting the feature.
  *
@@ -52,7 +52,7 @@ const extend = <
 };
 
 /**
- * Take text `inputs` list and converts it into an object of all arguments
+ * Take a list of string `args` and converts it into an object of all arguments
  * suitable for the `compatibility.liquid` template.
  */
 const parseCompatibilityOpts = (...args: string[]): CompatibilityOptions => {

--- a/source/helpers/components/compatibility.ts
+++ b/source/helpers/components/compatibility.ts
@@ -52,7 +52,7 @@ const extend = <
 };
 
 /**
- * Take text `inputs` list and convert it into an object of all arguments
+ * Take text `inputs` list and converts it into an object of all arguments
  * suitable for the `compatibility.liquid` template.
  */
 const parseCompatibilityOpts = (...args: string[]): CompatibilityOptions => {

--- a/source/helpers/components/compatibility.ts
+++ b/source/helpers/components/compatibility.ts
@@ -23,24 +23,84 @@ import { liquidEngine } from '../engines';
  * This takes an optional Markdown block (`details`) that should provide more
  * information about the implementation differences or the old behavior.
  */
-export const compatibility = async (
-  details: string,
-  dart: string | boolean | null = null,
-  libsass: string | boolean | null = null,
-  node: string | boolean | null = null,
-  ruby: string | boolean | null = null,
-  feature: string | null = null,
-  useMarkdown = true,
-) =>
-  liquidEngine.renderFile('compatibility', {
+export const compatibility = async (details: string, ...opts: string[]) => {
+  const options = parseCompatibilityOpts(...opts);
+  return liquidEngine.renderFile('compatibility', {
     details: stripIndent(details),
-    dart,
-    libsass,
-    node,
-    ruby,
-    feature,
-    useMarkdown,
+    ...options,
   });
+};
+
+interface CompatibilityOptions {
+  dart: string | boolean | null;
+  libsass: string | boolean | null;
+  node: string | boolean | null;
+  ruby: string | boolean | null;
+  feature: string | null;
+  useMarkdown: boolean;
+}
+
+const extend = <
+  K extends keyof CompatibilityOptions,
+  V extends CompatibilityOptions[K],
+>(
+  value: V,
+  obj: CompatibilityOptions,
+  key: K,
+) => {
+  obj[key] = value;
+};
+
+/**
+ * Take text `inputs` list and convert it into an object of all arguments
+ * suitable for the `compatibility.liquid` template.
+ */
+const parseCompatibilityOpts = (...args: string[]): CompatibilityOptions => {
+  const keyValueRegex = /(\w+):(.*)/;
+  const defaults = {
+    dart: null,
+    libsass: null,
+    node: null,
+    ruby: null,
+    feature: null,
+    useMarkdown: true,
+  };
+  for (const input of args) {
+    if (typeof input !== 'string') {
+      throw new Error(
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        `Received non-string argument to {% compatibility %} tag:\n${input}`,
+      );
+    }
+    let [, key, value] = input.match(keyValueRegex) || [];
+    key = key?.trim();
+    value = value?.trim();
+    if (key && value && Object.hasOwn(defaults, key)) {
+      switch (value) {
+        case 'true':
+          (value as CompatibilityOptions[keyof CompatibilityOptions]) = true;
+          break;
+        case 'false':
+          (value as CompatibilityOptions[keyof CompatibilityOptions]) = false;
+          break;
+        case 'null':
+          (value as CompatibilityOptions[keyof CompatibilityOptions]) = null;
+          break;
+      }
+      extend(
+        value as CompatibilityOptions[keyof CompatibilityOptions],
+        defaults,
+        key as keyof CompatibilityOptions,
+      );
+    } else {
+      throw new Error(
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        `Received unexpected argument to {% compatibility %} tag:\n${input}`,
+      );
+    }
+  }
+  return defaults;
+};
 
 /**
  * Renders a single row for `compatibility`.

--- a/tool/typedoc-theme.js
+++ b/tool/typedoc-theme.js
@@ -5,7 +5,7 @@ function bind(fn, first) {
 }
 
 /**
- * Take text `input` and convert it into a string of all arguments suitable for
+ * Take text `input` and converts it into a string of all arguments suitable for
  * the `{% compatibility %}` tag.
  */
 function parseCompatibility(input) {

--- a/tool/typedoc-theme.js
+++ b/tool/typedoc-theme.js
@@ -9,18 +9,10 @@ function bind(fn, first) {
  * the `{% compatibility %}` tag.
  */
 function parseCompatibility(input) {
-  const keyValueRegex = /(\w+):\s*([^,]+)/g;
-  const results = [...input.matchAll(keyValueRegex)].map(([, key, value]) => {
-    value = value.trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.substring(1, value.length - 1);
-    }
-    return [key.trim(), value];
-  });
-  return results.map((args) => `'${args.join(': ')}'`).join(', ');
+  return input
+    .split(',')
+    .map((arg) => `'${arg.trim()}'`)
+    .join(', ');
 }
 
 class SassSiteRenderContext extends DefaultThemeRenderContext {

--- a/tool/typedoc-theme.js
+++ b/tool/typedoc-theme.js
@@ -10,13 +10,17 @@ function bind(fn, first) {
  */
 function parseCompatibility(input) {
   const keyValueRegex = /(\w+):\s*([^,]+)/g;
-  const defaults = { dart: null, libsass: null, node: null, ruby: null };
-  const results = Object.fromEntries(
-    [...input.matchAll(keyValueRegex)].map(([, key, value]) => [key, value]),
-  );
-  return Object.values({ ...defaults, ...results })
-    .map(String)
-    .join(', ');
+  const results = [...input.matchAll(keyValueRegex)].map(([, key, value]) => {
+    value = value.trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.substring(1, value.length - 1);
+    }
+    return [key.trim(), value];
+  });
+  return results.map((args) => `'${args.join(': ')}'`).join(', ');
 }
 
 class SassSiteRenderContext extends DefaultThemeRenderContext {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&2361)

Implements [@jerivas's suggestion](https://github.com/oddbird/sass-site/pull/57#discussion_r1212028088).