### PR TITLE
Add indented syntax mode to playground

### DIFF
--- a/source/assets/js/playground.ts
+++ b/source/assets/js/playground.ts
@@ -6,7 +6,11 @@ import debounce from 'lodash/debounce';
 import {compileString, info, Logger, OutputStyle, Syntax} from 'sass';
 
 import {displayForConsoleLog} from './playground/console-utils.js';
-import {editorSetup, outputSetup} from './playground/editor-setup.js';
+import {
+  changeSyntax,
+  editorSetup,
+  outputSetup,
+} from './playground/editor-setup.js';
 import {
   deserializeState,
   customLoader,
@@ -34,6 +38,9 @@ function setupPlayground() {
     set(state: PlaygroundState, prop: keyof PlaygroundState, ...rest) {
       // Set state first so called functions have access
       const set = Reflect.set(state, prop, ...rest);
+      if (prop === 'inputFormat') {
+        changeSyntax(editor, state.inputFormat === 'indented');
+      }
       if (['inputFormat', 'outputFormat'].includes(prop)) {
         updateButtonState();
         debouncedUpdateCSS();
@@ -70,6 +77,10 @@ function setupPlayground() {
     ],
     parent: document.querySelector('.sl-code-is-source') || undefined,
   });
+
+  if (playgroundState.inputFormat === 'indented') {
+    changeSyntax(editor, true);
+  }
 
   // Setup CSS view
   const viewer = new EditorView({

--- a/source/assets/js/playground/editor-setup.ts
+++ b/source/assets/js/playground/editor-setup.ts
@@ -22,7 +22,7 @@ import {
   syntaxHighlighting,
 } from '@codemirror/language';
 import {lintKeymap} from '@codemirror/lint';
-import {EditorState} from '@codemirror/state';
+import {EditorState, Compartment} from '@codemirror/state';
 import {
   dropCursor,
   highlightActiveLine,
@@ -34,6 +34,15 @@ import {
 } from '@codemirror/view';
 
 import {playgroundHighlightStyle} from './theme.js';
+import {EditorView} from 'codemirror';
+
+const syntax = new Compartment();
+
+const changeSyntax = (view: EditorView, indented = false) => {
+  view.dispatch({
+    effects: syntax.reconfigure(langSass({indented})),
+  });
+};
 
 const editorSetup = (() => [
   [
@@ -61,7 +70,7 @@ const editorSetup = (() => [
       indentWithTab,
     ]),
   ],
-  langSass(),
+  syntax.of(langSass()),
 ])();
 
 const outputSetup = (() => [
@@ -77,4 +86,4 @@ const outputSetup = (() => [
   langCss(),
 ])();
 
-export {editorSetup, outputSetup};
+export {changeSyntax, editorSetup, outputSetup};


### PR DESCRIPTION
## Description
The language mode has an indented switch, but it wasn't getting enabled. This adds highlighting to the indented syntax.

## Related Issue(s)



## Steps to test/reproduce
In the playground, enable the Indented mode, and enter some values. Highlighting and completion should work as expected. Reload the page, and the highlighting should still be there.